### PR TITLE
Fix a typo in docs

### DIFF
--- a/docs/pages/docs/Advanced Features/isolates.md
+++ b/docs/pages/docs/Advanced Features/isolates.md
@@ -1,7 +1,7 @@
 ---
 data:
   title: Isolates
-  description: Acessing drift databases on multiple isolates.
+  description: Accessing drift databases on multiple isolates.
 template: layouts/docs/single
 ---
 {% assign snippets = 'package:drift_docs/snippets/isolates.dart.excerpt.json' | readString | json_decode %}


### PR DESCRIPTION
Correct "acessing" to "accessing" in docs.